### PR TITLE
docs(sdk): update stale version in Python SDK README example

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -14,7 +14,7 @@ scanner binary itself into your environment's `bin/`, so there is nothing else t
 
 ```console
 $ airom --version
-airom 0.1.1
+airom 0.1.3
 
 $ airom fs ./my-app -o table          # the CLI, globally
 ```


### PR DESCRIPTION
## Summary

The example output in `sdk/python/README.md` (under the `pip install airom` section) still shows `airom 0.1.1`, while the current release on PyPI is **0.1.3**. This updates the example to match.

Note: the released 0.1.3 wheels themselves are correct — the binary is stamped from `__version__` via `hatch_build.py`, and a fresh `pip install airom` reports `airom 0.1.3`. This is purely documentation drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)