### PR TITLE
feat(diff): airom diff — the semantic AI delta between two AIBOMs, as a per-PR control

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ report even when tests reach it too.
 airom fs . --include-tests    # when the question is "what do our tests reach for?"
 ```
 
+## AIBOM diff
+
+A scan answers *"what AI is in this repo?"* — a snapshot. The question security teams live with is **"what AI changed?"** `airom diff` compares two native AIBOM documents and reports the semantic delta: components added, removed, and changed, keyed by the stable component ID. Version is not part of identity, so a version bump reads as a field change on one component, never as a remove+add pair — and evidence churn is not compared, so two scans of unchanged code diff as empty.
+
+```bash
+airom scan . -o json=head.json && airom diff base.json head.json   # what changed?
+airom diff base.json head.json --format markdown                   # ready to post as a PR comment
+airom diff base.json head.json --fail-on "hosted-llm|local-model-file"   # no new AI providers without sign-off
+airom diff base.json head.json --exit-code 1                       # any AI change fails the build
+```
+
+This turns AIROM from a point-in-time inventory into a **per-PR control**: scan the base branch and the head, diff the two, post the markdown to the PR, and gate the merge on the delta you refuse to accept — a new hosted model, new local weights, a new vector store, a component that just picked up a `pickle-import` risk. Removals never trip the gate. Three formats — `table`, `markdown`, `json` — all projections of the same result; details in **[docs/cli.md](docs/cli.md)**.
+
 ## Model lifecycle (EOL)
 
 The risk and CVE overlays answer questions about *risk*. This one answers a question about *time*: **what in this stack stops working, and when?** A retired hosted model is not a vulnerability you weigh — on the shutdown date the provider's API stops answering and the app breaks, patched or not.

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -140,6 +140,27 @@ airom k8s --manifests ./deploy/k8s --offline
 
 ## Inspection commands
 
+### airom diff
+
+Compare two native AIBOM documents and report the semantic delta: components added,
+removed, and changed, keyed by the stable component ID. A version bump reads as a field
+change on one component, never as a remove+add pair; evidence churn is not compared, so
+two scans of unchanged code diff as empty.
+
+```bash title="airom diff"
+airom diff old.json new.json
+airom diff base.json head.json --format markdown
+airom diff base.json head.json --fail-on "hosted-llm|local-model-file"
+airom diff base.json head.json --exit-code 1
+```
+
+Exactly two native AIBOM JSON files are required (`airom scan <target> -o json=<file>`);
+other formats are refused explicitly. `--format` selects one of `table` (default),
+`markdown` (ready to post as a PR comment), or `json`. The gate flags work like scan's,
+evaluated over the added and changed components only — removals never trip the gate, and
+`compliance:` terms are rejected. Test-scoped components are excluded unless
+`--include-tests` is set.
+
 ### airom detectors list
 
 List every detector with its selection status. Honors `--select` and `--rules`, so

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,7 @@ airom
 ├── repo <url|path>
 ├── image <ref>            # --input tar, --platform; remote→daemon→tarball→layout chain
 ├── k8s [context]          # --namespace | -A; --manifests <dir> (offline mode)
+├── diff <old> <new>       # semantic delta between two native AIBOMs; --format table|markdown|json
 ├── detectors {list|explain <id>}     # the explainability view
 ├── rules {list|lint <file>|test <file>}
 ├── dev {new-rulepack <name>|new-detector <name>}   # contributor scaffolding
@@ -227,6 +228,38 @@ $ airom k8s prod -A -o cyclonedx=cluster-aibom.json
 $ airom k8s --manifests ./deploy/rendered --offline
 ```
 
+### `airom diff <old-aibom.json> <new-aibom.json>`
+
+Compare two native AIBOM documents (`airom scan <target> -o json=<file>`) and report the
+**semantic delta**: components added, removed, and changed, keyed by the stable component
+ID. Version is deliberately not part of component identity (§9.2), so a version bump reads
+as a field change on one component — never as a remove+add pair. Evidence churn
+(occurrence counts, detector sets) is not compared, and confidence is compared by band, so
+two scans of unchanged code diff as empty. The scan root and test-scoped components are
+excluded by default (`--include-tests` to count them).
+
+One format to stdout, selected with `--format`:
+
+| Format | For |
+|---|---|
+| `table` (default) | terminals — summary box + added/removed/changed tables |
+| `markdown` | CI — ready to post as a PR comment |
+| `json` | tooling — full component snapshots plus field-level changes |
+
+The gate flags work like scan's, evaluated over the **added and changed** components only:
+`--fail-on` names the AI delta you refuse to merge, `--exit-code N` alone fails on any
+added or changed component. Removals never trip the gate — a policy names AI you do not
+want to appear, and a removal is that policy succeeding. `compliance:` terms are rejected
+(they gate a scan's framework mapping, not a delta). Wrong-format input (CycloneDX, SARIF)
+is refused explicitly rather than diffed as empty.
+
+```console
+$ airom diff old.json new.json
+$ airom diff base.json head.json --format markdown > aibom-diff.md
+$ airom diff base.json head.json --fail-on "hosted-llm|local-model-file"
+$ airom diff base.json head.json --exit-code 1     # any AI change fails the build
+```
+
 ### `airom detectors {list | explain <id>}`
 
 Capability-as-data: every detector's ID, version, tags, and exactly what it looks at —
@@ -318,6 +351,15 @@ $ airom scan . -o table -o cyclonedx=aibom.cdx.json -o sarif=airom.sarif
 
 ```console
 $ airom fs . --fail-on "hosted-llm&confidence>=0.9" --exit-code 1 -o table
+```
+
+**PR gate — surface and gate the AI delta a pull request introduces:**
+
+```console
+$ airom repo https://github.com/acme/rag-service.git -o json=base.json   # base branch
+$ airom fs . -o json=head.json                                           # PR checkout
+$ airom diff base.json head.json --format markdown > aibom-diff.md       # post as PR comment
+$ airom diff base.json head.json --fail-on "hosted-llm|local-model-file"
 ```
 
 **Air-gapped image scan from a build artifact:**

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -106,6 +106,7 @@ Exit codes: 0 = scan completed (findings are NOT failures); use
 		newRepoCmd(),
 		newImageCmd(),
 		newK8sCmd(),
+		newDiffCmd(),
 		newDetectorsCmd(),
 		newRulesCmd(),
 		newDevCmd(),

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -12,12 +12,11 @@ import (
 	"github.com/airomhq/airom/internal/source"
 )
 
-// exactArgs mirrors cobra.ExactArgs(1) but keeps a usage hint in the
-// error, since SilenceUsage suppresses cobra's own help echo. Every current
-// command takes at most one positional, so the count is fixed.
-func exactArgs(what string) cobra.PositionalArgs {
+// exactArgs mirrors cobra.ExactArgs but keeps a usage hint in the error,
+// since SilenceUsage suppresses cobra's own help echo.
+func exactArgs(n int, what string) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
+		if len(args) != n {
 			return &app.UsageError{Err: fmt.Errorf("%s requires %s (got %d)\nRun '%s --help' for usage",
 				cmd.Name(), what, len(args), cmd.CommandPath())}
 		}
@@ -57,7 +56,7 @@ func newScanCmd() *cobra.Command {
 		Short:   "Scan a target with scheme auto-detection (dir | git URL | image ref)",
 		Long: `Scan auto-detects the target scheme in order: existing local path -> git URL
 -> image reference. Explicit prefixes force interpretation: dir:, repo:, image:.`,
-		Args: exactArgs("exactly one <target>"),
+		Args: exactArgs(1, "exactly one <target>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kind, target, err := source.DetectTarget(args[0])
 			if err != nil {
@@ -82,7 +81,7 @@ func newFSCmd() *cobra.Command {
 		Use:     "fs <path>",
 		GroupID: groupScan,
 		Short:   "Scan a directory tree",
-		Args:    exactArgs("exactly one <path>"),
+		Args:    exactArgs(1, "exactly one <path>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := os.Stat(args[0]); err != nil {
 				return &app.UsageError{Err: fmt.Errorf("cannot scan %q: %w", args[0], err)}
@@ -97,7 +96,7 @@ func newRepoCmd() *cobra.Command {
 		Use:     "repo <url|path>",
 		GroupID: groupScan,
 		Short:   "Scan a git repository (remote URL: shallow clone; local path: worktree)",
-		Args:    exactArgs("exactly one <url|path>"),
+		Args:    exactArgs(1, "exactly one <url|path>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWith(cmd, app.SourceRepo, args[0])
 		},

--- a/internal/cli/detectors.go
+++ b/internal/cli/detectors.go
@@ -49,7 +49,7 @@ func newDetectorsCmd() *cobra.Command {
 		&cobra.Command{
 			Use:   "explain <id>",
 			Short: "Print one detector's full selector, needs, and rule count",
-			Args:  exactArgs("exactly one <id>"),
+			Args:  exactArgs(1, "exactly one <id>"),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				infos, err := detectorInfos(cmd)
 				if err != nil {

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -32,7 +32,7 @@ func newDevRulePackCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "new-rulepack <name>",
 		Short: "Scaffold a rule pack (rules/<category>/<name>.yaml) plus fixtures",
-		Args:  exactArgs("exactly one <name>"),
+		Args:  exactArgs(1, "exactly one <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			if !nameRe.MatchString(name) {
@@ -95,7 +95,7 @@ func newDevDetectorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "new-detector <name>",
 		Short: "Scaffold a Go code detector (internal/detectors/<name>/) plus a contract test",
-		Args:  exactArgs("exactly one <name>"),
+		Args:  exactArgs(1, "exactly one <name>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			if !nameRe.MatchString(name) {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/airomhq/airom/internal/app"
+	"github.com/airomhq/airom/internal/diff"
+	"github.com/airomhq/airom/pkg/airom"
+)
+
+func newDiffCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "diff <old-aibom.json> <new-aibom.json>",
+		GroupID: groupInspect,
+		Short:   "Compare two native AIBOM documents: what AI was added, removed, or changed",
+		Long: `Diff two native AIBOM JSON documents (airom scan <target> -o json=<file>) and
+report the semantic delta: components added, removed, and changed, keyed by
+the stable component ID. Version is not part of identity, so a version bump
+reads as a field change on one component, never as a remove+add pair.
+Evidence churn (occurrence counts, detector sets) is not compared.
+
+Output is one format to stdout: table (default), markdown (ready to post as
+a PR comment), or json — selected with --format. The scan root and
+test-scoped components are excluded by default (--include-tests to count
+them).
+
+The gate flags work like scan's, evaluated over the added and changed
+components only: --fail-on names the AI delta you refuse to merge, and
+--exit-code N alone fails on any added or changed component. Removals never
+trip the gate. compliance: terms are not applicable to a diff.`,
+		Example: example(
+			[2]string{"What AI changed between two scans?", "airom diff old.json new.json"},
+			[2]string{"PR comment: scan base and head, then diff", "airom diff base.json head.json --format markdown"},
+			[2]string{"Fail CI when a PR introduces a new hosted model", `airom diff base.json head.json --fail-on "hosted-llm|local-model-file"`},
+			[2]string{"Fail CI on any AI change at all", "airom diff base.json head.json --exit-code 1"},
+		),
+		Args: exactArgs(2, "exactly two native AIBOM files: <old.json> <new.json>"),
+		RunE: runDiff,
+	}
+	return cmd
+}
+
+func runDiff(cmd *cobra.Command, args []string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("determine working directory: %w", err)
+	}
+	l, err := loadLayers(cmd.Flags(), wd)
+	if err != nil {
+		return err
+	}
+
+	includeTests, err := boolKey(l.k, "include-tests")
+	if err != nil {
+		return &app.UsageError{Err: err}
+	}
+	policy, exitCode, err := resolvePolicy(l.k)
+	if err != nil {
+		return &app.UsageError{Err: err}
+	}
+	if policy != nil && policy.ReferencesCompliance() {
+		return &app.UsageError{Err: fmt.Errorf("--fail-on %q: compliance terms gate a scan's framework mapping and are not applicable to a diff", policy)}
+	}
+	format, err := resolveDiffFormat(cmd)
+	if err != nil {
+		return err
+	}
+
+	oldInv, err := diff.Load(args[0])
+	if err != nil {
+		return err
+	}
+	newInv, err := diff.Load(args[1])
+	if err != nil {
+		return err
+	}
+
+	res := diff.Compute(oldInv, newInv, includeTests)
+	res.OldPath, res.NewPath = args[0], args[1]
+
+	// Emit first, gate last — the report must be complete before the exit
+	// code says anything about it (same order as app.Run).
+	if err := diff.Render(cmd.OutOrStdout(), format, res); err != nil {
+		return err
+	}
+	if policy != nil {
+		// The gated set is pre-filtered by --include-tests above, so the
+		// policy itself must not filter again.
+		gated := &airom.Inventory{Components: res.GateComponents()}
+		if policy.Matches(gated, true) {
+			return &app.PolicyExit{Code: exitCode}
+		}
+	}
+	return nil
+}
+
+// resolveDiffFormat picks the diff output format from the global --format
+// flag. Only the flag itself is consulted: a `format:` in .airom.yaml or
+// AIROM_FORMAT configures scan output (cyclonedx, sarif, …) and must not
+// break diff, whose format set is its own. -o/--output is scan-only and is
+// rejected explicitly rather than silently ignored.
+func resolveDiffFormat(cmd *cobra.Command) (string, error) {
+	if cmd.Flags().Changed("output") {
+		return "", &app.UsageError{Err: fmt.Errorf("diff renders one format to stdout; use --format %s, not -o/--output",
+			strings.Join(diff.Formats(), "|"))}
+	}
+	if !cmd.Flags().Changed("format") {
+		return diff.Formats()[0], nil
+	}
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return "", err
+	}
+	format = strings.TrimSpace(format)
+	for _, f := range diff.Formats() {
+		if format == f {
+			return format, nil
+		}
+	}
+	return "", &app.UsageError{Err: fmt.Errorf("unknown diff format %q (formats: %s)", format, strings.Join(diff.Formats(), ", "))}
+}

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -37,15 +37,23 @@ func writeAIBOM(t *testing.T, dir, name string, comps ...airom.Component) string
 func diffFixtures(t *testing.T) (oldPath, newPath string) {
 	t.Helper()
 	dir := t.TempDir()
-	oldPath = writeAIBOM(t, dir, "old.json",
-		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindFramework, Name: "langchain",
-			Version: airom.KnownString("0.2.1"), Confidence: 0.95},
+	oldPath = writeAIBOM(
+		t, dir, "old.json",
+		airom.Component{
+			ID: "airom:00000000000000aa", Kind: airom.KindFramework, Name: "langchain",
+			Version: airom.KnownString("0.2.1"), Confidence: 0.95,
+		},
 	)
-	newPath = writeAIBOM(t, dir, "new.json",
-		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindFramework, Name: "langchain",
-			Version: airom.KnownString("0.3.0"), Confidence: 0.95},
-		airom.Component{ID: "airom:00000000000000bb", Kind: airom.KindHostedLLM, Name: "gpt-4.1",
-			Provider: airom.KnownString("openai"), Confidence: 0.95},
+	newPath = writeAIBOM(
+		t, dir, "new.json",
+		airom.Component{
+			ID: "airom:00000000000000aa", Kind: airom.KindFramework, Name: "langchain",
+			Version: airom.KnownString("0.3.0"), Confidence: 0.95,
+		},
+		airom.Component{
+			ID: "airom:00000000000000bb", Kind: airom.KindHostedLLM, Name: "gpt-4.1",
+			Provider: airom.KnownString("openai"), Confidence: 0.95,
+		},
 	)
 	return oldPath, newPath
 }
@@ -174,8 +182,10 @@ func TestDiffIncludeTests(t *testing.T) {
 	dir := t.TempDir()
 	oldPath := writeAIBOM(t, dir, "old.json")
 	newPath := writeAIBOM(t, dir, "new.json",
-		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindHostedLLM, Name: "gpt-4.1",
-			Confidence: 0.9, TestOnly: true})
+		airom.Component{
+			ID: "airom:00000000000000aa", Kind: airom.KindHostedLLM, Name: "gpt-4.1",
+			Confidence: 0.9, TestOnly: true,
+		})
 
 	out, err := execute(t, "diff", oldPath, newPath)
 	if err != nil {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/airomhq/airom/internal/app"
+	"github.com/airomhq/airom/pkg/airom"
+)
+
+// writeAIBOM marshals a minimal native document to dir/name and returns its
+// path.
+func writeAIBOM(t *testing.T, dir, name string, comps ...airom.Component) string {
+	t.Helper()
+	root := airom.Component{ID: "airom:0000000000000000", Kind: airom.KindApplication, Name: "app"}
+	doc := airom.Inventory{
+		SchemaVersion: "1",
+		Source:        airom.SourceInfo{Kind: "fs", Target: name},
+		Root:          root.ID,
+		Components:    append([]airom.Component{root}, comps...),
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func diffFixtures(t *testing.T) (oldPath, newPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	oldPath = writeAIBOM(t, dir, "old.json",
+		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindFramework, Name: "langchain",
+			Version: airom.KnownString("0.2.1"), Confidence: 0.95},
+	)
+	newPath = writeAIBOM(t, dir, "new.json",
+		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindFramework, Name: "langchain",
+			Version: airom.KnownString("0.3.0"), Confidence: 0.95},
+		airom.Component{ID: "airom:00000000000000bb", Kind: airom.KindHostedLLM, Name: "gpt-4.1",
+			Provider: airom.KnownString("openai"), Confidence: 0.95},
+	)
+	return oldPath, newPath
+}
+
+func TestDiffCommand(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	out, err := execute(t, "diff", oldPath, newPath)
+	if err != nil {
+		t.Fatalf("diff: %v", err)
+	}
+	for _, want := range []string{"AIBOM Diff", "1 added, 0 removed, 1 changed", "gpt-4.1", "langchain"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDiffCommandMarkdown(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	out, err := execute(t, "diff", oldPath, newPath, "--format", "markdown")
+	if err != nil {
+		t.Fatalf("diff --format markdown: %v", err)
+	}
+	if !strings.Contains(out, "## AIBOM diff") || !strings.Contains(out, "### Added") {
+		t.Errorf("markdown output:\n%s", out)
+	}
+}
+
+func TestDiffCommandJSON(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	out, err := execute(t, "diff", oldPath, newPath, "--format", "json")
+	if err != nil {
+		t.Fatalf("diff --format json: %v", err)
+	}
+	var doc struct {
+		Summary struct{ Added, Changed int } `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("json output does not parse: %v\n%s", err, out)
+	}
+	if doc.Summary.Added != 1 || doc.Summary.Changed != 1 {
+		t.Fatalf("summary = %+v", doc.Summary)
+	}
+}
+
+func TestDiffFailOnMatchesAddedComponent(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	out, err := execute(t, "diff", oldPath, newPath, "--fail-on", "hosted-llm")
+	var pe *app.PolicyExit
+	if !errors.As(err, &pe) || pe.Code != 1 {
+		t.Fatalf("err = %v, want PolicyExit code 1", err)
+	}
+	// The report is still emitted before the gate fires.
+	if !strings.Contains(out, "gpt-4.1") {
+		t.Errorf("gated diff swallowed its report:\n%s", out)
+	}
+}
+
+func TestDiffFailOnHonorsExitCode(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	_, err := execute(t, "diff", oldPath, newPath, "--fail-on", "hosted-llm", "--exit-code", "3")
+	var pe *app.PolicyExit
+	if !errors.As(err, &pe) || pe.Code != 3 {
+		t.Fatalf("err = %v, want PolicyExit code 3", err)
+	}
+}
+
+func TestDiffFailOnRemovalDoesNotTrip(t *testing.T) {
+	// vector-db exists only on the old side: a removal must not gate.
+	dir := t.TempDir()
+	oldPath := writeAIBOM(t, dir, "old.json",
+		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindVectorDB, Name: "chroma", Confidence: 0.9})
+	newPath := writeAIBOM(t, dir, "new.json")
+	if _, err := execute(t, "diff", oldPath, newPath, "--fail-on", "vector-db"); err != nil {
+		t.Fatalf("removal tripped the gate: %v", err)
+	}
+}
+
+func TestDiffExitCodeAloneFailsOnAnyDelta(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	_, err := execute(t, "diff", oldPath, newPath, "--exit-code", "1")
+	var pe *app.PolicyExit
+	if !errors.As(err, &pe) || pe.Code != 1 {
+		t.Fatalf("err = %v, want PolicyExit code 1", err)
+	}
+
+	// No delta → no gate.
+	if _, err := execute(t, "diff", oldPath, oldPath, "--exit-code", "1"); err != nil {
+		t.Fatalf("identical documents tripped the gate: %v", err)
+	}
+}
+
+func TestDiffUsageErrors(t *testing.T) {
+	oldPath, newPath := diffFixtures(t)
+	cases := [][]string{
+		{"diff", oldPath},
+		{"diff", oldPath, newPath, "--format", "cyclonedx"},
+		{"diff", oldPath, newPath, "-o", "table"},
+		{"diff", oldPath, newPath, "--fail-on", "compliance:gap"},
+		{"diff", oldPath, newPath, "--fail-on", "no-such-term"},
+	}
+	for _, args := range cases {
+		_, err := execute(t, args...)
+		var uerr *app.UsageError
+		if !errors.As(err, &uerr) {
+			t.Errorf("%v: err = %v, want UsageError", args, err)
+		}
+	}
+}
+
+func TestDiffMissingFileIsFatalNotUsage(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeAIBOM(t, dir, "old.json")
+	_, err := execute(t, "diff", oldPath, filepath.Join(dir, "absent.json"))
+	if err == nil {
+		t.Fatal("missing file accepted")
+	}
+	var uerr *app.UsageError
+	var pe *app.PolicyExit
+	if errors.As(err, &uerr) || errors.As(err, &pe) {
+		t.Fatalf("err = %v, want a plain fatal error", err)
+	}
+}
+
+func TestDiffIncludeTests(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := writeAIBOM(t, dir, "old.json")
+	newPath := writeAIBOM(t, dir, "new.json",
+		airom.Component{ID: "airom:00000000000000aa", Kind: airom.KindHostedLLM, Name: "gpt-4.1",
+			Confidence: 0.9, TestOnly: true})
+
+	out, err := execute(t, "diff", oldPath, newPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "test-scoped component(s) skipped") {
+		t.Errorf("skipped test-scoped components not surfaced:\n%s", out)
+	}
+
+	out, err = execute(t, "diff", oldPath, newPath, "--include-tests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "gpt-4.1") {
+		t.Errorf("--include-tests did not count the fixture component:\n%s", out)
+	}
+}

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -97,7 +97,7 @@ func newRulesLintCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "lint <file>",
 		Short: "Validate a rule pack (or a model lifecycle catalog) against its full contract",
-		Args:  exactArgs("exactly one <file>"),
+		Args:  exactArgs(1, "exactly one <file>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// The signed bundle carries both rule packs and lifecycle catalogs,
 			// so one lint command serves both — a maintainer should not have to
@@ -122,7 +122,7 @@ func newRulesTestCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "test <file>",
 		Short: "Run a rule pack against its fixtures (no Go toolchain needed)",
-		Args:  exactArgs("exactly one <file>"),
+		Args:  exactArgs(1, "exactly one <file>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// A publishing pipeline runs lint AND test over every YAML in the
 			// bundle. A lifecycle catalog has no fixtures to run, so say that

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,302 @@
+// Package diff compares two native AIBOM documents (schemaVersion "1") and
+// reports what changed between them: components added, removed, and changed,
+// keyed by the stable component ID (ARCHITECTURE.md §9.2). Version is
+// deliberately not part of component identity, so a version bump surfaces as
+// a field change on one component — never as a remove+add pair.
+//
+// The comparison is a pure function of the two documents: no scanning, no
+// network, deterministic output (invariant P7).
+package diff
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/airomhq/airom/internal/writer"
+	"github.com/airomhq/airom/pkg/airom"
+)
+
+// Load reads a native AIBOM JSON document. It refuses other formats
+// (CycloneDX, SARIF) explicitly: they lack the lossless fields the diff is
+// keyed on, and a wrong-format file must say so rather than diff as empty.
+func Load(path string) (*airom.Inventory, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- user-specified input path
+	if err != nil {
+		return nil, err
+	}
+	// Probe the version before the full decode, so a CycloneDX/SARIF file
+	// reports "wrong format", not whichever field happens to unmarshal badly
+	// first.
+	var probe struct {
+		SchemaVersion string `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return nil, fmt.Errorf("%s: not a native AIBOM JSON document: %w", path, err)
+	}
+	if probe.SchemaVersion != "1" {
+		return nil, fmt.Errorf("%s: schemaVersion %q is not a native AIBOM document (want \"1\"; generate one with 'airom scan <target> -o json=%s')",
+			path, probe.SchemaVersion, path)
+	}
+	var inv airom.Inventory
+	if err := json.Unmarshal(b, &inv); err != nil {
+		return nil, fmt.Errorf("%s: not a native AIBOM JSON document: %w", path, err)
+	}
+	return &inv, nil
+}
+
+// FieldChange is one changed field on a component present in both documents.
+type FieldChange struct {
+	Field string `json:"field"`
+	Old   string `json:"old"`
+	New   string `json:"new"`
+}
+
+// Change is a component present in both documents with at least one changed
+// field. Component is the new-side snapshot.
+type Change struct {
+	Component airom.Component `json:"component"`
+	Fields    []FieldChange   `json:"fields"`
+}
+
+// Result is the semantic delta between two AIBOM documents.
+type Result struct {
+	OldPath, NewPath string
+	Old, New         *airom.Inventory
+
+	Added   []airom.Component
+	Removed []airom.Component
+	Changed []Change
+
+	Unchanged int
+	// TestOnlySkipped counts components excluded because every occurrence is
+	// test scaffolding (Component.TestOnly), summed across both documents.
+	TestOnlySkipped int
+}
+
+// Empty reports whether the diff found no added, removed, or changed
+// components.
+func (r *Result) Empty() bool {
+	return len(r.Added) == 0 && len(r.Removed) == 0 && len(r.Changed) == 0
+}
+
+// GateComponents returns the components a CI gate evaluates: everything
+// added plus the new-side snapshot of everything changed. Removals are not
+// gated — a policy names AI you do not want to appear, and a removal is that
+// policy succeeding.
+func (r *Result) GateComponents() []airom.Component {
+	out := make([]airom.Component, 0, len(r.Added)+len(r.Changed))
+	out = append(out, r.Added...)
+	for _, c := range r.Changed {
+		out = append(out, c.Component)
+	}
+	return out
+}
+
+// Compute diffs two inventories. The scan-root application components are
+// excluded — the root is the scan subject, not an AI asset, and its identity
+// tracks the target name rather than any AI usage. Test-scoped components
+// are excluded unless includeTests is set, mirroring every other default
+// surface (docs: "Test scope").
+func Compute(oldInv, newInv *airom.Inventory, includeTests bool) *Result {
+	r := &Result{Old: oldInv, New: newInv}
+
+	skip := func(inv *airom.Inventory, c *airom.Component) bool {
+		if c.ID == inv.Root || c.Kind == airom.KindApplication {
+			return true
+		}
+		if c.TestOnly && !includeTests {
+			r.TestOnlySkipped++
+			return true
+		}
+		return false
+	}
+
+	oldByID := make(map[airom.ID]*airom.Component, len(oldInv.Components))
+	for i := range oldInv.Components {
+		c := &oldInv.Components[i]
+		if !skip(oldInv, c) {
+			oldByID[c.ID] = c
+		}
+	}
+
+	seen := make(map[airom.ID]bool, len(newInv.Components))
+	for i := range newInv.Components {
+		c := &newInv.Components[i]
+		if skip(newInv, c) {
+			continue
+		}
+		seen[c.ID] = true
+		prev, ok := oldByID[c.ID]
+		if !ok {
+			r.Added = append(r.Added, *c)
+			continue
+		}
+		if fields := compareComponents(prev, c); len(fields) > 0 {
+			r.Changed = append(r.Changed, Change{Component: *c, Fields: fields})
+		} else {
+			r.Unchanged++
+		}
+	}
+
+	for i := range oldInv.Components {
+		c := &oldInv.Components[i]
+		if _, kept := oldByID[c.ID]; kept && !seen[c.ID] {
+			r.Removed = append(r.Removed, *c)
+		}
+	}
+
+	sortComponents(r.Added)
+	sortComponents(r.Removed)
+	sort.SliceStable(r.Changed, func(i, j int) bool {
+		return componentLess(&r.Changed[i].Component, &r.Changed[j].Component)
+	})
+	return r
+}
+
+func sortComponents(cs []airom.Component) {
+	sort.SliceStable(cs, func(i, j int) bool { return componentLess(&cs[i], &cs[j]) })
+}
+
+// componentLess orders by (kind, name, id) — the reading order of the table
+// writer, made total by the unique ID.
+func componentLess(a, b *airom.Component) bool {
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	return a.ID < b.ID
+}
+
+// compareComponents reports the identity- and risk-surface fields that
+// differ between two snapshots of one component. Evidence churn (occurrence
+// counts, detector sets) is deliberately not compared: two scans of the same
+// code with different rule versions would otherwise read as wall-to-wall
+// change. Confidence is compared by band for the same reason — 0.87 → 0.88
+// is noise, medium → high is signal.
+func compareComponents(oldC, newC *airom.Component) []FieldChange {
+	var out []FieldChange
+	add := func(field, oldV, newV string) {
+		if oldV != newV {
+			out = append(out, FieldChange{Field: field, Old: oldV, New: newV})
+		}
+	}
+
+	add("kind", string(oldC.Kind), string(newC.Kind))
+	add("name", oldC.Name, newC.Name)
+	add("group", oldC.Group, newC.Group)
+	add("version", optDisplay(oldC.Version), optDisplay(newC.Version))
+	add("provider", optDisplay(oldC.Provider), optDisplay(newC.Provider))
+	add("purl", oldC.PURL, newC.PURL)
+	add("licenses", licensesKey(oldC.Licenses), licensesKey(newC.Licenses))
+	add("confidence", oldC.Confidence.Band(), newC.Confidence.Band())
+	add("risks", risksKey(oldC.Risks), risksKey(newC.Risks))
+	add("vulnerabilities", vulnsKey(oldC.Vulnerabilities), vulnsKey(newC.Vulnerabilities))
+	add("eol", eolKey(oldC.EOL), eolKey(newC.EOL))
+	add("testOnly", boolKey(oldC.TestOnly), boolKey(newC.TestOnly))
+	return out
+}
+
+// optDisplay renders a tri-state string for comparison and display: Known is
+// its value, Unknown is "unknown", Absent is "".
+func optDisplay(o airom.OptString) string {
+	switch o.P {
+	case airom.PresenceKnown:
+		return o.V
+	case airom.PresenceUnknown:
+		return "unknown"
+	default:
+		return ""
+	}
+}
+
+func boolKey(b bool) string {
+	if b {
+		return "true"
+	}
+	return ""
+}
+
+// licensesKey canonicalizes a license list into a sorted, comparable string.
+func licensesKey(ls []airom.License) string {
+	parts := make([]string, 0, len(ls))
+	for _, l := range ls {
+		switch {
+		case l.SPDXID != "":
+			parts = append(parts, l.SPDXID)
+		case l.Expression != "":
+			parts = append(parts, l.Expression)
+		case l.Name != "":
+			parts = append(parts, l.Name)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+// risksKey canonicalizes the artifact-risk overlay into "id(severity)"
+// entries, sorted and deduplicated.
+func risksKey(rs []airom.ArtifactRisk) string {
+	set := map[string]bool{}
+	for _, r := range rs {
+		set[fmt.Sprintf("%s(%s)", r.ID, r.Severity)] = true
+	}
+	return joinSet(set)
+}
+
+// vulnsKey canonicalizes the CVE overlay into sorted advisory IDs.
+func vulnsKey(vs []airom.Vulnerability) string {
+	set := map[string]bool{}
+	for _, v := range vs {
+		set[v.ID] = true
+	}
+	return joinSet(set)
+}
+
+// eolKey renders the lifecycle overlay: the state, plus the shutdown date
+// when known. Nil means the catalog made no claim, rendered as "".
+func eolKey(l *airom.Lifecycle) string {
+	if l == nil {
+		return ""
+	}
+	if l.Shutdown != nil {
+		return fmt.Sprintf("%s (shutdown %s)", l.State, l.Shutdown)
+	}
+	return string(l.State)
+}
+
+func joinSet(set map[string]bool) string {
+	parts := make([]string, 0, len(set))
+	for p := range set {
+		parts = append(parts, p)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+// minLocation returns the smallest (path:line) occurrence of a component, or
+// "" if it has none — the same deterministic evidence pointer the compliance
+// report uses.
+func minLocation(c *airom.Component) string {
+	best := ""
+	for _, o := range c.Evidence.Occurrences {
+		if o.Location.Path == "" {
+			continue
+		}
+		loc := o.Location.Path
+		if o.Location.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", o.Location.Path, o.Location.Line)
+		}
+		if best == "" || loc < best {
+			best = loc
+		}
+	}
+	return best
+}
+
+// confidence renders a component confidence with the shared §6.2 formatting.
+func confidence(c airom.Confidence) string { return writer.FormatConfidence(c) }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,303 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/airomhq/airom/pkg/airom"
+)
+
+func comp(id, kind, name string, mut ...func(*airom.Component)) airom.Component {
+	c := airom.Component{
+		ID:         airom.ID(id),
+		Kind:       airom.ComponentKind(kind),
+		Name:       name,
+		Confidence: 0.95,
+		Evidence: airom.Evidence{Occurrences: []airom.Occurrence{{
+			Location:   airom.Location{Path: "src/agent.py", Line: 42},
+			DetectorID: "rules/openai/model-literal",
+			Method:     airom.MethodSourceCode,
+			Confidence: 0.95,
+		}}},
+	}
+	for _, m := range mut {
+		m(&c)
+	}
+	return c
+}
+
+func inv(target string, comps ...airom.Component) *airom.Inventory {
+	root := comp("airom:0000000000000000", string(airom.KindApplication), "app")
+	return &airom.Inventory{
+		SchemaVersion: "1",
+		Source:        airom.SourceInfo{Kind: "fs", Target: target},
+		Root:          root.ID,
+		Components:    append([]airom.Component{root}, comps...),
+	}
+}
+
+func TestComputeClassifiesAddedRemovedChanged(t *testing.T) {
+	oldInv := inv("old",
+		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) {
+			c.Version = airom.KnownString("0.2.1")
+		}),
+		comp("airom:00000000000000bb", "hosted-llm", "gpt-4o"),
+	)
+	newInv := inv("new",
+		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) {
+			c.Version = airom.KnownString("0.3.0")
+		}),
+		comp("airom:00000000000000cc", "hosted-llm", "gpt-4.1", func(c *airom.Component) {
+			c.Provider = airom.KnownString("openai")
+		}),
+	)
+
+	r := Compute(oldInv, newInv, false)
+
+	if len(r.Added) != 1 || r.Added[0].Name != "gpt-4.1" {
+		t.Fatalf("Added = %+v, want exactly gpt-4.1", r.Added)
+	}
+	if len(r.Removed) != 1 || r.Removed[0].Name != "gpt-4o" {
+		t.Fatalf("Removed = %+v, want exactly gpt-4o", r.Removed)
+	}
+	if len(r.Changed) != 1 {
+		t.Fatalf("Changed = %+v, want exactly langchain", r.Changed)
+	}
+	ch := r.Changed[0]
+	if ch.Component.Name != "langchain" || len(ch.Fields) != 1 {
+		t.Fatalf("changed fields = %+v, want one version change", ch.Fields)
+	}
+	if f := ch.Fields[0]; f.Field != "version" || f.Old != "0.2.1" || f.New != "0.3.0" {
+		t.Fatalf("field change = %+v", f)
+	}
+	if r.Unchanged != 0 {
+		t.Fatalf("Unchanged = %d, want 0", r.Unchanged)
+	}
+	if r.Empty() {
+		t.Fatal("Empty() = true for a non-empty diff")
+	}
+}
+
+func TestComputeIgnoresNoise(t *testing.T) {
+	// Confidence inside one band and evidence churn are not changes.
+	oldInv := inv("t", comp("airom:00000000000000aa", "hosted-llm", "gpt-4.1", func(c *airom.Component) {
+		c.Confidence = 0.91
+	}))
+	newInv := inv("t", comp("airom:00000000000000aa", "hosted-llm", "gpt-4.1", func(c *airom.Component) {
+		c.Confidence = 0.97
+		c.Evidence.Occurrences = append(c.Evidence.Occurrences, c.Evidence.Occurrences[0])
+	}))
+	r := Compute(oldInv, newInv, false)
+	if !r.Empty() || r.Unchanged != 1 {
+		t.Fatalf("want 1 unchanged and no delta, got %+v", r)
+	}
+}
+
+func TestComputeSurfacesOverlayChanges(t *testing.T) {
+	oldInv := inv("t", comp("airom:00000000000000aa", "local-model-file", "model.pt"))
+	newInv := inv("t", comp("airom:00000000000000aa", "local-model-file", "model.pt", func(c *airom.Component) {
+		c.Risks = []airom.ArtifactRisk{{ID: airom.RiskPickleImport, Severity: "high"}}
+	}))
+	r := Compute(oldInv, newInv, false)
+	if len(r.Changed) != 1 || r.Changed[0].Fields[0].Field != "risks" {
+		t.Fatalf("want a risks field change, got %+v", r.Changed)
+	}
+	if got := r.Changed[0].Fields[0].New; !strings.Contains(got, "AIROM-RISK-PICKLE-IMPORT(high)") {
+		t.Fatalf("risks new = %q", got)
+	}
+}
+
+func TestComputeSkipsRootAndTestOnly(t *testing.T) {
+	oldInv := inv("old")
+	newInv := inv("new", comp("airom:00000000000000aa", "hosted-llm", "gpt-4.1", func(c *airom.Component) {
+		c.TestOnly = true
+	}))
+
+	r := Compute(oldInv, newInv, false)
+	if !r.Empty() {
+		t.Fatalf("root/test-only leaked into the diff: %+v", r)
+	}
+	if r.TestOnlySkipped != 1 {
+		t.Fatalf("TestOnlySkipped = %d, want 1", r.TestOnlySkipped)
+	}
+
+	// Opting in counts it.
+	r = Compute(oldInv, newInv, true)
+	if len(r.Added) != 1 || r.TestOnlySkipped != 0 {
+		t.Fatalf("with includeTests want 1 added, got %+v", r)
+	}
+}
+
+func TestGateComponentsIsAddedPlusChanged(t *testing.T) {
+	oldInv := inv("t",
+		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("1") }),
+		comp("airom:00000000000000bb", "vector-db", "chroma"),
+	)
+	newInv := inv("t",
+		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("2") }),
+		comp("airom:00000000000000cc", "hosted-llm", "gpt-4.1"),
+	)
+	got := Compute(oldInv, newInv, false).GateComponents()
+	if len(got) != 2 {
+		t.Fatalf("gate set = %+v, want added gpt-4.1 + changed langchain", got)
+	}
+	names := []string{got[0].Name, got[1].Name}
+	if names[0] != "gpt-4.1" || names[1] != "langchain" {
+		t.Fatalf("gate names = %v", names)
+	}
+}
+
+func TestLoadRoundTripAndRejections(t *testing.T) {
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "good.json")
+	b, err := json.Marshal(inv("t", comp("airom:00000000000000aa", "hosted-llm", "gpt-4.1")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(good, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(good)
+	if err != nil {
+		t.Fatalf("Load(good) = %v", err)
+	}
+	if len(got.Components) != 2 || got.Source.Target != "t" {
+		t.Fatalf("loaded inventory = %+v", got)
+	}
+
+	cdx := filepath.Join(dir, "bom.json")
+	if err := os.WriteFile(cdx, []byte(`{"bomFormat":"CycloneDX","specVersion":"1.6"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(cdx); err == nil || !strings.Contains(err.Error(), "schemaVersion") {
+		t.Fatalf("Load(cyclonedx) = %v, want schemaVersion rejection", err)
+	}
+
+	junk := filepath.Join(dir, "junk.json")
+	if err := os.WriteFile(junk, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(junk); err == nil {
+		t.Fatal("Load(junk) succeeded")
+	}
+
+	if _, err := Load(filepath.Join(dir, "absent.json")); err == nil {
+		t.Fatal("Load(absent) succeeded")
+	}
+}
+
+func result(t *testing.T) *Result {
+	t.Helper()
+	oldInv := inv("repo@base",
+		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("0.2.1") }),
+		comp("airom:00000000000000bb", "vector-db", "chroma"),
+	)
+	newInv := inv("repo@head",
+		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("0.3.0") }),
+		comp("airom:00000000000000cc", "hosted-llm", "gpt-4.1", func(c *airom.Component) { c.Provider = airom.KnownString("openai") }),
+	)
+	r := Compute(oldInv, newInv, false)
+	r.OldPath, r.NewPath = "base.json", "head.json"
+	return r
+}
+
+func TestRenderTable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "table", result(t)); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"AIBOM Diff", "repo@base", "repo@head",
+		"1 added, 1 removed, 1 changed, 0 unchanged",
+		"Added (1)", "Removed (1)", "Changed (1)",
+		"gpt-4.1", "chroma", "src/agent.py:42",
+		"version", "0.2.1", "0.3.0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	i := inv("t", comp("airom:00000000000000aa", "hosted-llm", "gpt-4.1"))
+	if err := Render(&buf, "table", Compute(i, i, false)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No AI changes.") {
+		t.Errorf("empty diff table output:\n%s", buf.String())
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "markdown", result(t)); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"## AIBOM diff — `repo@base` → `repo@head`",
+		"**1 added · 1 removed · 1 changed** — 0 unchanged.",
+		"### Added", "### Removed", "### Changed",
+		"| hosted-llm | gpt-4.1 | - | openai | 0.95 | `src/agent.py:42` |",
+		"version: `0.2.1` → `0.3.0`",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, "json", result(t)); err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Old     struct{ Path, Target string } `json:"old"`
+		Summary struct {
+			Added, Removed, Changed, Unchanged int
+		} `json:"summary"`
+		Added []airom.Component `json:"added"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("json output does not parse: %v", err)
+	}
+	if doc.Old.Path != "base.json" || doc.Old.Target != "repo@base" {
+		t.Fatalf("old ref = %+v", doc.Old)
+	}
+	if doc.Summary.Added != 1 || doc.Summary.Removed != 1 || doc.Summary.Changed != 1 {
+		t.Fatalf("summary = %+v", doc.Summary)
+	}
+	if len(doc.Added) != 1 || doc.Added[0].Name != "gpt-4.1" {
+		t.Fatalf("added = %+v", doc.Added)
+	}
+}
+
+func TestRenderUnknownFormat(t *testing.T) {
+	if err := Render(&bytes.Buffer{}, "sarif", result(t)); err == nil {
+		t.Fatal("unknown format accepted")
+	}
+}
+
+func TestRenderDeterminism(t *testing.T) {
+	for _, format := range Formats() {
+		var a, b bytes.Buffer
+		if err := Render(&a, format, result(t)); err != nil {
+			t.Fatal(err)
+		}
+		if err := Render(&b, format, result(t)); err != nil {
+			t.Fatal(err)
+		}
+		if a.String() != b.String() {
+			t.Errorf("%s render is not deterministic", format)
+		}
+	}
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -41,13 +41,15 @@ func inv(target string, comps ...airom.Component) *airom.Inventory {
 }
 
 func TestComputeClassifiesAddedRemovedChanged(t *testing.T) {
-	oldInv := inv("old",
+	oldInv := inv(
+		"old",
 		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) {
 			c.Version = airom.KnownString("0.2.1")
 		}),
 		comp("airom:00000000000000bb", "hosted-llm", "gpt-4o"),
 	)
-	newInv := inv("new",
+	newInv := inv(
+		"new",
 		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) {
 			c.Version = airom.KnownString("0.3.0")
 		}),
@@ -133,11 +135,13 @@ func TestComputeSkipsRootAndTestOnly(t *testing.T) {
 }
 
 func TestGateComponentsIsAddedPlusChanged(t *testing.T) {
-	oldInv := inv("t",
+	oldInv := inv(
+		"t",
 		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("1") }),
 		comp("airom:00000000000000bb", "vector-db", "chroma"),
 	)
-	newInv := inv("t",
+	newInv := inv(
+		"t",
 		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("2") }),
 		comp("airom:00000000000000cc", "hosted-llm", "gpt-4.1"),
 	)
@@ -193,11 +197,13 @@ func TestLoadRoundTripAndRejections(t *testing.T) {
 
 func result(t *testing.T) *Result {
 	t.Helper()
-	oldInv := inv("repo@base",
+	oldInv := inv(
+		"repo@base",
 		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("0.2.1") }),
 		comp("airom:00000000000000bb", "vector-db", "chroma"),
 	)
-	newInv := inv("repo@head",
+	newInv := inv(
+		"repo@head",
 		comp("airom:00000000000000aa", "framework", "langchain", func(c *airom.Component) { c.Version = airom.KnownString("0.3.0") }),
 		comp("airom:00000000000000cc", "hosted-llm", "gpt-4.1", func(c *airom.Component) { c.Provider = airom.KnownString("openai") }),
 	)

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -1,0 +1,213 @@
+package diff
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/airomhq/airom/internal/writer/tablew"
+	"github.com/airomhq/airom/pkg/airom"
+)
+
+// Formats lists the diff output formats, default first.
+func Formats() []string { return []string{"table", "markdown", "json"} }
+
+// Render writes the diff in one format. Formats are pure projections of the
+// same Result: table for terminals, markdown for PR comments, json for
+// tooling.
+func Render(w io.Writer, format string, r *Result) error {
+	switch format {
+	case "table":
+		renderTable(w, r)
+		return nil
+	case "markdown":
+		renderMarkdown(w, r)
+		return nil
+	case "json":
+		return renderJSON(w, r)
+	default:
+		return fmt.Errorf("unknown diff format %q", format)
+	}
+}
+
+// ── table ───────────────────────────────────────────────────────────────────
+
+func renderTable(w io.Writer, r *Result) {
+	lines := []string{
+		fmt.Sprintf("%-13s %s", "Old", r.Old.Source.Target),
+		fmt.Sprintf("%-13s %s", "New", r.New.Source.Target),
+		fmt.Sprintf("%-13s %d added, %d removed, %d changed, %d unchanged",
+			"Components", len(r.Added), len(r.Removed), len(r.Changed), r.Unchanged),
+	}
+	if r.TestOnlySkipped > 0 {
+		lines = append(lines, fmt.Sprintf("%-13s %d test-scoped component(s) skipped (--include-tests to count them)",
+			"Test scope", r.TestOnlySkipped))
+	}
+	tablew.SummaryBox(w, "AIBOM Diff", lines)
+
+	if r.Empty() {
+		fmt.Fprintln(w, "\nNo AI changes.")
+		return
+	}
+
+	section := func(title string, comps []airom.Component) {
+		if len(comps) == 0 {
+			return
+		}
+		fmt.Fprintf(w, "\n%s (%d)\n", title, len(comps))
+		rows := make([][]string, 0, len(comps))
+		for i := range comps {
+			c := &comps[i]
+			rows = append(rows, []string{
+				string(c.Kind), c.Name, dash(optDisplay(c.Version)), dash(optDisplay(c.Provider)),
+				confidence(c.Confidence), dash(minLocation(c)),
+			})
+		}
+		tablew.BoxTable(w, []string{"KIND", "NAME", "VERSION", "PROVIDER", "CONF", "LOCATION"}, rows)
+	}
+	section("Added", r.Added)
+	section("Removed", r.Removed)
+
+	if len(r.Changed) > 0 {
+		fmt.Fprintf(w, "\nChanged (%d)\n", len(r.Changed))
+		var rows [][]string
+		for i := range r.Changed {
+			ch := &r.Changed[i]
+			for j, f := range ch.Fields {
+				kind, name := string(ch.Component.Kind), ch.Component.Name
+				if j > 0 { // repeat rows read as one component
+					kind, name = "", ""
+				}
+				rows = append(rows, []string{kind, name, f.Field, dash(f.Old), dash(f.New)})
+			}
+		}
+		tablew.BoxTable(w, []string{"KIND", "NAME", "FIELD", "OLD", "NEW"}, rows)
+	}
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// ── markdown ────────────────────────────────────────────────────────────────
+
+// renderMarkdown emits a PR-comment-ready report: a one-line verdict, then
+// one table per section. Deliberately self-contained — it names the targets
+// so the comment still reads correctly when detached from the CI run.
+func renderMarkdown(w io.Writer, r *Result) {
+	fmt.Fprintf(w, "## AIBOM diff — `%s` → `%s`\n\n", mdEscape(r.Old.Source.Target), mdEscape(r.New.Source.Target))
+
+	if r.Empty() {
+		fmt.Fprintf(w, "**No AI changes.** %d component(s) unchanged.\n", r.Unchanged)
+		writeMDTestNote(w, r)
+		return
+	}
+
+	fmt.Fprintf(w, "**%d added · %d removed · %d changed** — %d unchanged.\n",
+		len(r.Added), len(r.Removed), len(r.Changed), r.Unchanged)
+	writeMDTestNote(w, r)
+
+	section := func(title string, comps []airom.Component) {
+		if len(comps) == 0 {
+			return
+		}
+		fmt.Fprintf(w, "\n### %s\n\n", title)
+		fmt.Fprintln(w, "| Kind | Name | Version | Provider | Confidence | Evidence |")
+		fmt.Fprintln(w, "|---|---|---|---|---|---|")
+		for i := range comps {
+			c := &comps[i]
+			loc := minLocation(c)
+			if loc != "" {
+				loc = "`" + loc + "`"
+			}
+			fmt.Fprintf(w, "| %s | %s | %s | %s | %s | %s |\n",
+				c.Kind, mdEscape(c.Name), dash(mdEscape(optDisplay(c.Version))),
+				dash(mdEscape(optDisplay(c.Provider))), confidence(c.Confidence), dash(mdEscape(loc)))
+		}
+	}
+	section("Added", r.Added)
+	section("Removed", r.Removed)
+
+	if len(r.Changed) > 0 {
+		fmt.Fprintf(w, "\n### Changed\n\n")
+		fmt.Fprintln(w, "| Kind | Name | Change |")
+		fmt.Fprintln(w, "|---|---|---|")
+		for i := range r.Changed {
+			ch := &r.Changed[i]
+			for j, f := range ch.Fields {
+				kind, name := string(ch.Component.Kind), mdEscape(ch.Component.Name)
+				if j > 0 {
+					kind, name = "", ""
+				}
+				fmt.Fprintf(w, "| %s | %s | %s: `%s` → `%s` |\n",
+					kind, name, f.Field, dash(mdEscape(f.Old)), dash(mdEscape(f.New)))
+			}
+		}
+	}
+}
+
+func writeMDTestNote(w io.Writer, r *Result) {
+	if r.TestOnlySkipped > 0 {
+		fmt.Fprintf(w, "\n_%d test-scoped component(s) not compared (`--include-tests` to count them)._\n", r.TestOnlySkipped)
+	}
+}
+
+// mdEscape neutralizes the Markdown table delimiter so a value containing a
+// pipe cannot break the table layout (same rule as the compliance report).
+func mdEscape(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '|' {
+			out = append(out, '\\')
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// ── json ────────────────────────────────────────────────────────────────────
+
+// docRef identifies one side of the diff for machine consumers.
+type docRef struct {
+	Path      string    `json:"path"`
+	Target    string    `json:"target"`
+	Serial    string    `json:"serial"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type jsonSummary struct {
+	Added           int `json:"added"`
+	Removed         int `json:"removed"`
+	Changed         int `json:"changed"`
+	Unchanged       int `json:"unchanged"`
+	TestOnlySkipped int `json:"testOnlySkipped,omitempty"`
+}
+
+type jsonDoc struct {
+	Old     docRef            `json:"old"`
+	New     docRef            `json:"new"`
+	Summary jsonSummary       `json:"summary"`
+	Added   []airom.Component `json:"added,omitempty"`
+	Removed []airom.Component `json:"removed,omitempty"`
+	Changed []Change          `json:"changed,omitempty"`
+}
+
+func renderJSON(w io.Writer, r *Result) error {
+	doc := jsonDoc{
+		Old: docRef{Path: r.OldPath, Target: r.Old.Source.Target, Serial: r.Old.Serial, Timestamp: r.Old.Timestamp},
+		New: docRef{Path: r.NewPath, Target: r.New.Source.Target, Serial: r.New.Serial, Timestamp: r.New.Timestamp},
+		Summary: jsonSummary{
+			Added: len(r.Added), Removed: len(r.Removed), Changed: len(r.Changed),
+			Unchanged: r.Unchanged, TestOnlySkipped: r.TestOnlySkipped,
+		},
+		Added: r.Added, Removed: r.Removed, Changed: r.Changed,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	return enc.Encode(doc)
+}

--- a/internal/writer/tablew/tablew.go
+++ b/internal/writer/tablew/tablew.go
@@ -226,7 +226,7 @@ func writeSummary(w io.Writer, inv *airom.Inventory, comps []airom.Component) {
 		}
 	}
 
-	summaryBox(w, "Scan Summary", lines)
+	SummaryBox(w, "Scan Summary", lines)
 }
 
 // writeTable renders the component table with box-drawing borders, columns
@@ -258,7 +258,7 @@ func writeTable(w io.Writer, comps []airom.Component, anyVuln, anyEOL bool) {
 		row = append(row, locationCell(c), fmt.Sprintf("%d occ", len(c.Evidence.Occurrences)))
 		rows = append(rows, row)
 	}
-	boxTable(w, headers, rows)
+	BoxTable(w, headers, rows)
 }
 
 // ── rendering helpers ───────────────────────────────────────────────────────
@@ -312,8 +312,10 @@ func isWide(r rune) bool {
 
 func kv(k, v string) string { return fmt.Sprintf("%-13s %s", k, v) }
 
-// summaryBox draws a single-column box with the title set into the top border.
-func summaryBox(w io.Writer, title string, lines []string) {
+// SummaryBox draws a single-column box with the title set into the top border.
+// Exported for renderers of non-Inventory shapes (internal/diff) that share
+// the table writer's visual language.
+func SummaryBox(w io.Writer, title string, lines []string) {
 	inner := dispWidth("─ " + title + " ")
 	for _, l := range lines {
 		if dispWidth(l) > inner {
@@ -328,8 +330,9 @@ func summaryBox(w io.Writer, title string, lines []string) {
 	fmt.Fprintln(w, "└"+strings.Repeat("─", inner+2)+"┘")
 }
 
-// boxTable draws a bordered table with per-column widths.
-func boxTable(w io.Writer, headers []string, rows [][]string) {
+// BoxTable draws a bordered table with per-column widths. Exported for the
+// same reason as SummaryBox.
+func BoxTable(w io.Writer, headers []string, rows [][]string) {
 	n := len(headers)
 	width := make([]int, n)
 	for i, h := range headers {
@@ -720,7 +723,7 @@ func writeEOLTable(w io.Writer, comps []airom.Component) {
 		})
 	}
 	fmt.Fprintf(w, "\nModel lifecycle (%d)\n", len(rows))
-	boxTable(w, headers, tableRows)
+	BoxTable(w, headers, tableRows)
 
 	// Provenance as a footnote rather than a column: every row from a provider
 	// cites the same page, so repeating a wrapped URL per row would crowd out


### PR DESCRIPTION
## What

`airom diff <old-aibom.json> <new-aibom.json>` — a new command in the inspect group that compares two native AIBOM documents and reports the **semantic delta**: components added, removed, and changed, keyed by the stable component ID.

```console
$ airom diff base.json head.json
$ airom diff base.json head.json --format markdown          # PR-comment ready
$ airom diff base.json head.json --fail-on "hosted-llm|local-model-file"
$ airom diff base.json head.json --exit-code 1              # any AI change fails the build
```

## Why this is a game-changing feature

Today a scan answers *"what AI is in this repo?"* — a snapshot you run before an audit. The question security teams actually live with is **"what AI changed?"** — and right now they answer it with grep and hope. `diff` changes AIROM's category: from a point-in-time inventory tool into a **per-PR control**. Scan the base branch and the head, diff the two, post the markdown to the PR, and gate the merge on the delta you refuse to accept.

Concretely, a PR comment produced by `--format markdown` reads like this:

> ## AIBOM diff — `repo@base` → `repo@head`
>
> **2 added · 0 removed · 1 changed** — 182 unchanged.
>
> ### Added
>
> | Kind | Name | Version | Provider | Confidence | Evidence |
> |---|---|---|---|---|---|
> | hosted-llm | gpt-4.1 | - | openai | 0.95 | `src/agent.py:42` |
> | vector-db | pinecone | 3.2.1 | pinecone | 0.985 | `requirements.txt:7` |
>
> ### Changed
>
> | Kind | Name | Change |
> |---|---|---|
> | framework | langchain | version: `0.2.16` → `0.3.0` |

That is the review a security team wants on every PR that touches AI — a new hosted model, new local weights, a new vector store, a component that just picked up a `pickle-import` risk — with `file:line` evidence, produced offline and deterministically. `--fail-on "hosted-llm"` becomes an approval workflow: *no new AI providers without sign-off*. This is the feature that makes AIROM something you install in CI and run on every PR, not something you remember to run before an audit.

It also lands almost for free on the existing foundation, which is the point of the frozen native format:

- **Identity is already diff-shaped.** Component IDs are minted from a canonical key that deliberately excludes version (§9.2), so a version bump surfaces as a field change on one component — never as a remove+add pair. The diff is a map lookup, not a matching heuristic.
- **The gate is the existing policy grammar, verbatim.** `--fail-on`/`--exit-code` reuse `app.ParsePolicy` unchanged, evaluated over the added and changed components only. Zero new grammar; unknown terms still fail loudly.
- **The native format is a versioned API** (`schemaVersion: "1"`), so diffing documents produced by different AIROM builds is supported by contract.

## Design decisions

- **Noise is not a change.** Evidence churn (occurrence counts, detector sets) is not compared, and confidence is compared by band (`0.87 → 0.88` is noise, `medium → high` is signal) — so two scans of unchanged code diff as empty, which is what makes the CI gate trustworthy.
- **Removals never trip the gate.** A policy names AI you do not want to appear; a removal is that policy succeeding.
- **The compared surface is identity + risk overlays**: kind, name, group, version, provider, purl, licenses, confidence band, artifact risks, CVEs, EOL state, test scope.
- **Scan root and test-scoped components are excluded by default** (`--include-tests` to count them), and the skip count is surfaced, mirroring the test-scope discipline everywhere else.
- **Wrong-format input is refused explicitly.** A CycloneDX/SARIF file reports "not a native AIBOM document" with the command that generates one — it must not diff as empty.
- **`compliance:` terms are rejected** in the diff gate: they gate a scan's framework mapping, not a delta.
- **Emit first, gate last**, same as `app.Run`: the report is always complete before the exit code says anything about it.
- Three formats — `table` (summary box + box tables, matching the scan table's visual language), `markdown`, `json` (full component snapshots plus field-level changes) — all pure projections of one `Result`.

## Mechanics

- `internal/diff` — `Load` (schemaVersion-probed native reader), `Compute` (pure, deterministic), `Render` (three projections).
- `internal/cli/diff.go` — the command; flags resolve through the existing koanf layering (`--fail-on`, `--exit-code`, `--include-tests` are the existing globals; `--format` is consulted flag-only so a scan-oriented `format:` in `.airom.yaml` cannot break diff).
- `exactArgs` generalized to take a count (first two-positional command).
- `tablew.BoxTable`/`SummaryBox` exported so a non-`Inventory` renderer can share the table writer's visual language.
- Docs: `docs/cli.md` (command tree, command section, PR-gate recipe), `docs-site/reference/cli.mdx`, README section.

## Testing

- `internal/diff`: classification (added/removed/changed), noise suppression, overlay-change surfacing, root/test-scope skipping, gate-set semantics, Load round-trip + wrong-format/junk/missing rejections, all three renderers, determinism.
- `internal/cli`: command-level tests for all three formats, gate matching (`--fail-on`, `--exit-code`, custom codes), removal-does-not-trip, usage-vs-fatal error classes, `--include-tests`.
- Full suite green under `-race`; smoke-tested end-to-end against the e2e golden AIBOMs.

## Follow-ups (not in this PR)

- A GitHub Action that scans base + head, posts the markdown comment, and gates — the packaging that makes this a one-liner to adopt.
- Diff-native gate terms (`added:`, `removed:`, `changed:`) if users want to gate on removals or distinguish adds from changes.
- Relationship-level diff (RAG-pipeline edge changes).
