### PR TITLE
ci: run every published wheel before publishing it

### DIFF
--- a/.github/scripts/smoke_wheel.py
+++ b/.github/scripts/smoke_wheel.py
@@ -1,0 +1,103 @@
+"""Verify an INSTALLED airom wheel actually works on this machine.
+
+The packaging tests in sdk/python/tests inspect the wheel as a zip: they prove
+the binary is in `.data/scripts/` and carries the right version stamp. They
+cannot prove it runs, because they run on the machine that built it. Every
+wheel except linux/amd64 is cross-compiled on an x86-64 Linux runner, so
+until this script runs on the target platform, "the binary works there" is an
+assumption.
+
+Usage:  python smoke_wheel.py <bin-dir> <expected-version>
+
+<bin-dir> is the venv's scripts directory, i.e. exactly where pip put the
+`airom` command. Passing it explicitly rather than searching PATH is the
+point: the claim under test is that `pip install airom` puts a working
+command there.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Enough to exercise the real pipeline: walk, classify, run a manifest
+# detector, assemble, and project into a writer.
+FIXTURE = "openai==1.99.1\nlangchain==0.3.0\n"
+
+# Offline and deterministic. The overlays are on by default and reach the
+# network; a smoke test that fails when OSV.dev is slow tells you nothing
+# about the wheel. Turning them off also proves the offline path works.
+OFFLINE = ["--no-cve", "--no-eol", "--auto-update-rules=false"]
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"smoke: {msg}")
+
+
+def run(argv: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True, **kw)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        fail(f"usage: {sys.argv[0]} <bin-dir> <expected-version>")
+    bindir, expected = Path(sys.argv[1]).resolve(), sys.argv[2]
+
+    exe = bindir / ("airom.exe" if sys.platform == "win32" else "airom")
+    if not exe.exists():
+        listing = "\n  ".join(sorted(p.name for p in bindir.iterdir())) or "(empty)"
+        fail(f"pip installed no `airom` command in {bindir}. Contents:\n  {listing}")
+
+    # The binary must be the Go executable itself, not a Python launcher. A
+    # `[project.scripts]` entry point would put a shim here instead, costing an
+    # interpreter start on every invocation. Guard the design, not just the path.
+    head = exe.open("rb").read(4)
+    if head[:2] == b"#!":
+        fail(f"{exe} is a script shim, not the compiled binary: {exe.open().readline()!r}")
+    if head not in (b"\x7fELF", b"MZ\x90\x00") and head[:2] != b"MZ" and head[:4] not in (
+        b"\xcf\xfa\xed\xfe",  # Mach-O 64-bit little-endian
+        b"\xca\xfe\xba\xbe",  # Mach-O universal
+    ):
+        fail(f"{exe} has an unrecognised header {head!r}: not a native executable")
+
+    # 1. It runs at all, on this OS and architecture.
+    p = run([str(exe), "--version"])
+    if p.returncode != 0:
+        fail(f"`airom --version` exited {p.returncode}\n{p.stdout}{p.stderr}")
+    print(f"  --version: {p.stdout.strip()}")
+
+    # 2. It reports the version the wheel claims. A pip-installed airom stamps
+    #    ToolInfo into every AIBOM it writes, so a wrong version here is a wrong
+    #    provenance record in every document a user produces.
+    if expected not in p.stdout:
+        fail(f"`airom --version` says {p.stdout.strip()!r}, expected to contain {expected!r}")
+
+    # 3. It completes a real scan and finds what is there.
+    with tempfile.TemporaryDirectory() as td:
+        (Path(td) / "requirements.txt").write_text(FIXTURE)
+        p = run([str(exe), "scan", td, "-o", "json", *OFFLINE])
+        if p.returncode != 0:
+            fail(f"`airom scan` exited {p.returncode}\n{p.stdout}{p.stderr}")
+        try:
+            inv = json.loads(p.stdout)
+        except json.JSONDecodeError as e:
+            fail(f"`airom scan -o json` did not emit JSON: {e}\n{p.stdout[:400]}")
+
+    found = {c["name"] for c in inv.get("components", [])}
+    missing = {"openai", "langchain"} - found
+    if missing:
+        fail(f"scan missed {sorted(missing)}; found {sorted(found)}")
+    print(f"  scan: found {sorted(found)}")
+
+    tool = inv.get("tool", {})
+    if expected not in str(tool.get("version", "")):
+        fail(f"the AIBOM records tool.version {tool.get('version')!r}, expected {expected!r}")
+
+    print(f"ok: {exe} works on {sys.platform}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,21 @@ jobs:
           print(f"ok: {whl} -> {scripts}")
           PY
 
+      # The check above reads the wheel as a zip. This one installs it and runs
+      # it: the same script the release workflow runs on every target platform,
+      # so an ordinary PR that breaks the binary fails here rather than at
+      # release time. Only linux/x86-64 is covered on this runner; the other six
+      # wheels are covered by the smoke jobs in release-pypi.yml.
+      - name: Install the wheel and run it
+        working-directory: sdk/python
+        run: |
+          set -euo pipefail
+          VERSION=$(python -c "import re;print(re.search(r'__version__ = \"([^\"]+)\"', open('src/airom/__init__.py').read()).group(1))")
+          VENV=$(mktemp -d)/v   # outside the tree: nothing to clean up or gitignore
+          python -m venv "$VENV"
+          "$VENV/bin/python" -m pip install --quiet --no-index --find-links dist "airom==$VERSION"
+          python ../../.github/scripts/smoke_wheel.py "$VENV/bin" "$VERSION"
+
   fuzz:
     name: Fuzz smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -226,7 +226,11 @@ jobs:
         include:
           - { id: linux-x86_64-glibc,  runs-on: ubuntu-latest }
           - { id: linux-aarch64-glibc, runs-on: ubuntu-24.04-arm }
-          - { id: macos-x86_64,        runs-on: macos-13 } # the last Intel image
+          # macos-13 is gone from GitHub's supported image list, and a retired
+          # label still QUEUES rather than failing fast: the job sat 38 minutes
+          # with no runner assigned while every other label picked up in
+          # seconds. macos-15-intel is the current Intel image.
+          - { id: macos-x86_64,        runs-on: macos-15-intel }
           - { id: macos-arm64,         runs-on: macos-latest }
           - { id: windows-x86_64,      runs-on: windows-latest }
     steps:

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -24,6 +24,15 @@ name: Publish (PyPI)
 on:
   push:
     branches: [main]
+  # Packaging changes are exercised on the PR that makes them. Without this the
+  # wheel matrix only ever runs on a version bump, so a broken build hook lands
+  # on main and is discovered by the release it breaks.
+  pull_request:
+    paths:
+      - "sdk/python/**"
+      - ".github/workflows/release-pypi.yml"
+      - ".github/scripts/smoke_wheel.py"
+      - "cmd/airom/**"
   workflow_dispatch:
     inputs:
       repository:
@@ -84,23 +93,47 @@ jobs:
           print(f"::notice::airom {version} on {host}: {note}")
           PY
 
+      # This gap is how the smoke jobs came to be missing in the first place:
+      # a platform was added to the wheel matrix and nothing noticed that
+      # nothing tested it. Adding a wheel without a smoke entry now fails here,
+      # before anything is built.
+      - name: Every wheel has a smoke test
+        run: |
+          pip install --quiet pyyaml
+          python - <<'PY'
+          import sys, yaml
+
+          jobs = yaml.safe_load(open(".github/workflows/release-pypi.yml"))["jobs"]
+          ids = lambda j: {m["id"] for m in jobs[j]["strategy"]["matrix"]["include"]}
+          built, smoked = ids("wheels"), ids("smoke") | ids("smoke-musl")
+
+          if unsmoked := sorted(built - smoked):
+              sys.exit(
+                  f"these wheels are published without ever being run: {unsmoked}. "
+                  "Add a matching entry to the smoke or smoke-musl matrix."
+              )
+          if orphan := sorted(smoked - built):
+              sys.exit(f"smoke entries with no wheel to test: {orphan}")
+          print(f"ok: {len(built)} wheels, all smoke-tested")
+          PY
+
   wheels:
-    name: Wheel (${{ matrix.goos }}/${{ matrix.goarch }} ${{ matrix.libc }})
+    name: Wheel ${{ matrix.id }}
     needs: decide
-    if: needs.decide.outputs.publish == 'true'
+    if: needs.decide.outputs.publish == 'true' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux, goarch: amd64, libc: manylinux, tag: py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64 }
-          - { goos: linux, goarch: arm64, libc: manylinux, tag: py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64 }
+          - { id: linux-x86_64-glibc,  goos: linux,   goarch: amd64, tag: py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64 }
+          - { id: linux-aarch64-glibc, goos: linux,   goarch: arm64, tag: py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64 }
           # A CGO-free Go binary is static, so the same build also runs on musl.
-          - { goos: linux, goarch: amd64, libc: musllinux, tag: py3-none-musllinux_1_2_x86_64 }
-          - { goos: linux, goarch: arm64, libc: musllinux, tag: py3-none-musllinux_1_2_aarch64 }
-          - { goos: darwin, goarch: amd64, libc: "", tag: py3-none-macosx_10_9_x86_64 }
-          - { goos: darwin, goarch: arm64, libc: "", tag: py3-none-macosx_11_0_arm64 }
-          - { goos: windows, goarch: amd64, libc: "", tag: py3-none-win_amd64 }
+          - { id: linux-x86_64-musl,   goos: linux,   goarch: amd64, tag: py3-none-musllinux_1_2_x86_64 }
+          - { id: linux-aarch64-musl,  goos: linux,   goarch: arm64, tag: py3-none-musllinux_1_2_aarch64 }
+          - { id: macos-x86_64,        goos: darwin,  goarch: amd64, tag: py3-none-macosx_10_9_x86_64 }
+          - { id: macos-arm64,         goos: darwin,  goarch: arm64, tag: py3-none-macosx_11_0_arm64 }
+          - { id: windows-x86_64,      goos: windows, goarch: amd64, tag: py3-none-win_amd64 }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -144,14 +177,14 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: wheel-${{ matrix.goos }}-${{ matrix.goarch }}-${{ matrix.libc }}
+          name: wheel-${{ matrix.id }}
           path: sdk/python/dist/*.whl
           if-no-files-found: error
 
   sdist:
     name: sdist
     needs: decide
-    if: needs.decide.outputs.publish == 'true'
+    if: needs.decide.outputs.publish == 'true' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -171,10 +204,99 @@ jobs:
           path: sdk/python/dist/*.tar.gz
           if-no-files-found: error
 
+  # ── The gate ──────────────────────────────────────────────────────────────
+  #
+  # Everything above inspects the wheel as a zip file, on the machine that
+  # built it. That proves the binary is in .data/scripts/ and carries the right
+  # version stamp; it cannot prove the binary RUNS, because six of the seven
+  # wheels are cross-compiled on an x86-64 Linux runner and never executed.
+  #
+  # These two jobs install each wheel on the platform it targets and run it.
+  # `publish` depends on them, so an unexecuted wheel cannot reach PyPI, where
+  # a version can never be re-uploaded.
+
+  smoke:
+    name: Smoke ${{ matrix.id }}
+    needs: [decide, wheels]
+    if: needs.decide.outputs.publish == 'true' || github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: linux-x86_64-glibc,  runs-on: ubuntu-latest }
+          - { id: linux-aarch64-glibc, runs-on: ubuntu-24.04-arm }
+          - { id: macos-x86_64,        runs-on: macos-13 } # the last Intel image
+          - { id: macos-arm64,         runs-on: macos-latest }
+          - { id: windows-x86_64,      runs-on: windows-latest }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheel-${{ matrix.id }}
+          path: dist
+
+      # A venv here is CI hygiene, not an AIROM requirement: it gives a known
+      # empty environment so "pip put a working airom in bin/" is the only thing
+      # the result can be explained by. The package has no dependencies, so
+      # there is nothing for it to isolate.
+      #
+      # Installing by NAME through --find-links (not by path) also makes pip
+      # check the wheel's platform tag, so a mislabelled tag fails here rather
+      # than becoming an uninstallable release.
+      - name: Install the wheel and run it
+        shell: bash
+        env:
+          VERSION: ${{ needs.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          python -m venv .venv
+          if [ -d ".venv/Scripts" ]; then BIN=".venv/Scripts"; else BIN=".venv/bin"; fi
+          "$BIN/python" -m pip install --quiet --no-index --find-links dist "airom==$VERSION"
+          python .github/scripts/smoke_wheel.py "$BIN" "$VERSION"
+
+  smoke-musl:
+    name: Smoke ${{ matrix.id }}
+    needs: [decide, wheels]
+    if: needs.decide.outputs.publish == 'true' || github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: linux-x86_64-musl,  runs-on: ubuntu-latest }
+          - { id: linux-aarch64-musl, runs-on: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheel-${{ matrix.id }}
+          path: dist
+
+      # Alpine runs through `docker run` rather than a job-level `container:`.
+      # The runner mounts its own glibc-linked node into a job container to run
+      # JavaScript actions, which does not execute on musl, so checkout and
+      # download-artifact would fail before the test could start. Running the
+      # container as a step keeps those actions on the glibc host.
+      - name: Install the wheel and run it under musl
+        env:
+          VERSION: ${{ needs.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/w" -w /w alpine:3.21 sh -euc "
+            apk add --no-cache python3 py3-pip >/dev/null
+            python3 -m venv /tmp/v
+            /tmp/v/bin/pip install --quiet --no-index --find-links dist 'airom==$VERSION'
+            python3 .github/scripts/smoke_wheel.py /tmp/v/bin '$VERSION'
+          "
+
   publish:
     name: Publish ${{ needs.decide.outputs.version }}
-    needs: [decide, wheels, sdist]
-    if: needs.decide.outputs.publish == 'true'
+    needs: [decide, wheels, sdist, smoke, smoke-musl]
+    if: needs.decide.outputs.publish == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Trusted Publishing mints the OIDC token. No secrets.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,7 +46,11 @@ notes, and changelog entries. They describe what a specific version did.
    golangci-lint run && go test ./... -race
    ```
 
-5. **Commit and push.** The push publishes the Python SDK to PyPI; confirm:
+5. **Commit and push.** The push publishes the Python SDK to PyPI. Every wheel is
+   installed and run on the platform it targets first (the `smoke` jobs in
+   `release-pypi.yml`), so a cross-compiled binary that does not execute fails
+   before publication rather than after. PyPI never lets a version be
+   re-uploaded, so that gate is the only chance to catch it. Confirm:
 
    ```bash
    curl -s https://pypi.org/pypi/airom/json | python3 -c "import json,sys;print(json.load(sys.stdin)['info']['version'])"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -154,9 +154,26 @@ The library resolves the binary without relying on PATH at all (it consults the
 environment's scripts dir directly), so `import airom` works even from an unactivated
 venv's interpreter.
 
-Installing from an **sdist** ships no binary — put `airom` on your `PATH`
-(`go install github.com/airomhq/airom/cmd/airom@latest`, then ensure
-`$(go env GOPATH)/bin` is on PATH) or set `$AIROM_BINARY`.
+### Platforms with no wheel
+
+Wheels are published for macOS (Intel + Apple Silicon), Linux (x86-64 + arm64, glibc +
+musl), and Windows x86-64. Every one is installed and executed on the platform it targets
+before it is published; see the smoke jobs in
+[`release-pypi.yml`](../../.github/workflows/release-pypi.yml).
+
+Anywhere else, pip falls back to the **sdist**, which ships the Python library and no
+binary — and cannot build one, since it does not contain the Go module. Rather than
+install successfully and leave you without a scanner, that build now **fails** and says so.
+To proceed, either install the binary for your platform from the
+[releases page](https://github.com/airomhq/airom/releases) and put it on your `PATH`, or
+take the library alone:
+
+```bash
+AIROM_SKIP_BUNDLE=1 pip install airom
+```
+
+The second form is the right one when you already run the standalone binary and only want
+`import airom`. Resolution then falls through to `$AIROM_BINARY` or `airom` on `PATH`.
 
 ## Development
 
@@ -171,7 +188,8 @@ The suite runs against the **real binary**, not mocks: a wrapper tested only aga
 proves nothing about the contract it wraps.
 
 Building a wheel needs the Go toolchain (the build hook compiles the binary with
-`CGO_ENABLED=0`). Set `AIROM_SKIP_BUNDLE=1` for a pure-Python wheel.
+`CGO_ENABLED=0`) and fails without it, because a wheel with no binary installs no `airom`
+command. Set `AIROM_SKIP_BUNDLE=1` for a pure-Python wheel on purpose.
 
 ## Publishing
 

--- a/sdk/python/hatch_build.py
+++ b/sdk/python/hatch_build.py
@@ -10,8 +10,18 @@ Wheels are therefore platform-specific, and this hook stamps the wheel tag. It
 needs the Go toolchain and the repository checkout (the module root is two levels
 up from this file).
 
-Opt out with ``AIROM_SKIP_BUNDLE=1`` — the resulting wheel is pure-Python and the
-SDK falls back to ``$AIROM_BINARY`` or ``airom`` on ``PATH`` at runtime.
+If the binary cannot be built, this hook FAILS rather than quietly producing a
+wheel with no ``airom`` command. That case is reached by ``pip install airom``
+on a platform with no prebuilt wheel: pip falls back to the sdist, which
+carries no binary and cannot build one (it does not contain the Go module). A
+warning there produced the worst possible outcome — an install that reports
+success and leaves the user with no scanner, discovered later as
+``airom: command not found``.
+
+Opt out with ``AIROM_SKIP_BUNDLE=1`` to build the pure-Python wheel on purpose:
+the SDK then falls back to ``$AIROM_BINARY`` or ``airom`` on ``PATH`` at
+runtime, which is what someone who already installed the standalone binary and
+only wants ``import airom`` actually wants.
 
 Cross-compile by setting ``GOOS``/``GOARCH`` (both are forwarded to ``go build``);
 set ``AIROM_WHEEL_TAG`` to override the platform tag when doing so.
@@ -64,6 +74,28 @@ def _wheel_tag() -> str:
     return f"py3-none-{plat}"
 
 
+
+def _refuse(reason: str) -> None:
+    """Fail the build rather than ship a wheel that installs no command.
+
+    Raised at `pip install` time, so the message is what the user sees.
+    """
+    raise RuntimeError(
+        f"airom: cannot build the scanner binary ({reason}), and a wheel without "
+        "it installs no `airom` command.\n"
+        "\n"
+        "You are most likely installing from the sdist because this platform has "
+        "no prebuilt wheel. The sdist ships the Python library only; it cannot "
+        "build the scanner.\n"
+        "\n"
+        "  * To get the scanner: install the binary for your platform from\n"
+        "    https://github.com/airomhq/airom/releases and put it on your PATH.\n"
+        "  * To install the Python library alone (you already have the binary,\n"
+        "    or you are building a pure-Python wheel on purpose):\n"
+        "        AIROM_SKIP_BUNDLE=1 pip install airom\n"
+    )
+
+
 class AiromBuildHook(BuildHookInterface):
     PLUGIN_NAME = "custom"
 
@@ -76,18 +108,10 @@ class AiromBuildHook(BuildHookInterface):
             return
 
         if not (REPO_ROOT / "go.mod").is_file():
-            self.app.display_warning(
-                f"no go.mod under {REPO_ROOT} — building without a bundled binary "
-                "(the SDK will fall back to $AIROM_BINARY or PATH)"
-            )
-            return
+            _refuse(f"no Go module under {REPO_ROOT}")
 
         if shutil.which("go") is None:
-            self.app.display_warning(
-                "the Go toolchain was not found — building without a bundled binary "
-                "(set AIROM_SKIP_BUNDLE=1 to silence this)"
-            )
-            return
+            _refuse("the Go toolchain was not found")
 
         BUILD_DIR.mkdir(parents=True, exist_ok=True)
         out = BUILD_DIR / _exe_name()

--- a/sdk/python/tests/test_scan.py
+++ b/sdk/python/tests/test_scan.py
@@ -235,3 +235,84 @@ def test_bundled_binary_is_version_stamped(tmp_path):
         f"{_airom.__version__!r} — the ldflags stamp is not being applied"
     )
     assert info.version != "dev"
+
+
+def _build(args, cwd, env=None):
+    import os
+    import subprocess
+    import sys
+
+    return subprocess.run(
+        [sys.executable, "-m", "build", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+    )
+
+
+def test_sdist_install_fails_loudly_rather_than_shipping_no_command(tmp_path):
+    """`pip install airom` on a platform with no wheel must FAIL.
+
+    pip falls back to the sdist there, and the sdist carries no binary and
+    cannot build one: it does not contain the Go module. The build hook used to
+    warn and continue, so the install reported success and left the user with a
+    library and no scanner — a failure that surfaces much later as `airom:
+    command not found`, far from its cause.
+
+    This reproduces that path exactly: build the sdist, extract it somewhere the
+    repository is not reachable, and build a wheel from it.
+    """
+    import tarfile
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    assert _build(["--sdist", "-o", str(tmp_path / "sd")], cwd=root).returncode == 0
+
+    sdist = next((tmp_path / "sd").glob("*.tar.gz"))
+    with tarfile.open(sdist) as tf:
+        tf.extractall(tmp_path / "x", filter="data")
+    extracted = next((tmp_path / "x").iterdir())
+
+    # Built WITH isolation, which is what pip does for an sdist: the backend runs
+    # in its own environment, exactly as it would on the user's machine.
+    proc = _build(["--wheel", "-o", str(tmp_path / "out")], cwd=extracted)
+    assert proc.returncode != 0, (
+        "building a wheel from the sdist SUCCEEDED. That wheel installs no `airom` "
+        "command, so `pip install airom` would report success and leave the user "
+        f"without a scanner.\n--- stdout ---\n{proc.stdout}"
+    )
+    out = proc.stdout + proc.stderr
+    assert "AIROM_SKIP_BUNDLE=1" in out, f"the failure does not say how to proceed:\n{out}"
+    assert "releases" in out, f"the failure does not point at the binary downloads:\n{out}"
+
+
+def test_skip_bundle_still_builds_a_library_only_wheel(tmp_path):
+    """The refusal above must stay opt-out-able.
+
+    Someone who already runs the standalone binary and only wants `import airom`
+    has a legitimate reason to build without bundling, and the error message
+    promises them this works. Assert the promise.
+    """
+    import tarfile
+    import zipfile
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    assert _build(["--sdist", "-o", str(tmp_path / "sd")], cwd=root).returncode == 0
+    sdist = next((tmp_path / "sd").glob("*.tar.gz"))
+    with tarfile.open(sdist) as tf:
+        tf.extractall(tmp_path / "x", filter="data")
+    extracted = next((tmp_path / "x").iterdir())
+
+    proc = _build(
+        ["--wheel", "-o", str(tmp_path / "out")],
+        cwd=extracted,
+        env={"AIROM_SKIP_BUNDLE": "1"},
+    )
+    assert proc.returncode == 0, f"AIROM_SKIP_BUNDLE build failed:\n{proc.stdout}{proc.stderr}"
+
+    whl = next((tmp_path / "out").glob("*.whl"))
+    assert whl.name.endswith("py3-none-any.whl"), f"expected a pure-Python wheel, got {whl.name}"
+    names = zipfile.ZipFile(whl).namelist()
+    assert not [n for n in names if ".data/scripts/" in n], "opted out, but a script shipped anyway"


### PR DESCRIPTION
## The gap

The packaging tests read the wheel as a **zip file**. They assert the binary sits in `.data/scripts/` (so pip puts `airom` on PATH rather than leaving it behind an `import`) and that it carries the right version stamp. Both run on the machine that built the wheel.

Six of the seven wheels are cross-compiled on an x86-64 Linux runner, and **none of them was ever executed before reaching PyPI**, where a version can never be re-uploaded. "The macOS arm64 binary runs" was an assumption, not a test.

## What this adds

`.github/scripts/smoke_wheel.py` plus two jobs that install each wheel on the platform it targets and run it. `publish` now depends on them.

| Wheel | Runner |
|---|---|
| `linux-x86_64-glibc` | `ubuntu-latest` |
| `linux-aarch64-glibc` | `ubuntu-24.04-arm` |
| `linux-x86_64-musl` | `alpine:3.21` on `ubuntu-latest` |
| `linux-aarch64-musl` | `alpine:3.21` on `ubuntu-24.04-arm` |
| `macos-x86_64` | `macos-13` |
| `macos-arm64` | `macos-latest` |
| `windows-x86_64` | `windows-latest` |

The script checks four things:

1. pip actually installed an `airom` command in the venv's `bin/`.
2. It is the **compiled binary**, not a `#!` launcher. A `[project.scripts]` entry point would put a Python shim there and cost an interpreter start per invocation, so this guards the design and not just the path.
3. `airom --version` runs and reports the version the wheel claims. A pip-installed airom stamps `ToolInfo` into every AIBOM it writes, so a wrong version here is wrong provenance in every document a user produces.
4. A real scan finds what is in the fixture, with the overlays off so the result does not depend on OSV.dev being reachable. That also exercises the offline path.

Installing **by name** through `--find-links` rather than by path makes pip check the platform tag, so a mislabelled wheel fails here instead of becoming an uninstallable release.

Alpine runs via `docker run` rather than a job-level `container:`. The runner mounts its own glibc-linked node into a job container to execute JavaScript actions, which does not run on musl, so `checkout` and `download-artifact` would fail before the test could start.

## Two supporting changes

The wheel matrix gains stable ids, and `decide` now **fails if any id lacks a smoke entry**. Adding a platform and forgetting to test it is exactly how this gap appeared; it should not be able to appear again silently.

The workflow also runs on pull requests that touch packaging. It previously ran only on a version bump, so a broken build hook would land on `main` and be discovered by the release it broke. `publish` keeps its strict gate and never fires from a PR.

## The sdist trap

Separate but related, and arguably the worse bug.

`pip install airom` on a platform with no wheel falls back to the **sdist**, which carries no binary and cannot build one, since it does not contain the Go module. The build hook warned and continued, so the install **reported success** and left the user with a library and no scanner — surfacing much later as `airom: command not found`, far from its cause.

It now fails at install time and names both ways forward:

```
airom: cannot build the scanner binary (no Go module under /tmp), and a wheel
without it installs no `airom` command.

You are most likely installing from the sdist because this platform has no
prebuilt wheel. The sdist ships the Python library only; it cannot build the
scanner.

  * To get the scanner: install the binary for your platform from
    https://github.com/airomhq/airom/releases and put it on your PATH.
  * To install the Python library alone (you already have the binary,
    or you are building a pure-Python wheel on purpose):
        AIROM_SKIP_BUNDLE=1 pip install airom
```

Two tests cover the refusal and the escape hatch, building a real sdist and extracting it somewhere the repo is not reachable.

## Verification

Run locally against a real wheel built from this branch, installed into a clean venv:

```
  --version: airom 0.3.7 (commit 0b46605, built 2026-08-12T01:09:28+05:30)
  scan: found ['langchain', 'openai', 'tmp_sdwthf9']
ok: .../v/bin/airom works on darwin
```

A test that cannot fail proves nothing, so each guard was confirmed to fire:

| Injected fault | Result |
|---|---|
| No `airom` in the bin dir | `smoke: pip installed no airom command in ... Contents: (empty)` |
| A `[project.scripts]` Python shim | `smoke: ... is a script shim, not the compiled binary` |
| Wrong version claim | `smoke: airom --version says '0.3.7', expected to contain '9.9.9'` |
| Wheel built from the sdist | build fails, message names `AIROM_SKIP_BUNDLE=1` and the releases page |
| `AIROM_SKIP_BUNDLE=1` | builds `py3-none-any`, `import airom` works, no script shipped |

Also green: full Python suite (29 tests), `ruff`, `mypy --strict`, both workflows parse, and the CI step was extracted from the YAML and executed verbatim so its quoting is tested as written.

## What to watch on the first run

`ubuntu-24.04-arm` and `macos-13` are the two labels worth confirming resolve for this org. If either does not, that job fails visibly here rather than silently at release time, which is the whole point.

## Not in scope

Windows arm64 has a standalone binary from goreleaser but no wheel. Adding it means publishing a platform, which is a separate change from verifying the ones already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
