### PR TITLE
feat(packaging): publish a Windows arm64 wheel

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -134,6 +134,7 @@ jobs:
           - { id: macos-x86_64,        goos: darwin,  goarch: amd64, tag: py3-none-macosx_10_9_x86_64 }
           - { id: macos-arm64,         goos: darwin,  goarch: arm64, tag: py3-none-macosx_11_0_arm64 }
           - { id: windows-x86_64,      goos: windows, goarch: amd64, tag: py3-none-win_amd64 }
+          - { id: windows-arm64,       goos: windows, goarch: arm64, tag: py3-none-win_arm64 }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -233,6 +234,7 @@ jobs:
           - { id: macos-x86_64,        runs-on: macos-15-intel }
           - { id: macos-arm64,         runs-on: macos-latest }
           - { id: windows-x86_64,      runs-on: windows-latest }
+          - { id: windows-arm64,       runs-on: windows-11-arm }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -157,8 +157,8 @@ venv's interpreter.
 ### Platforms with no wheel
 
 Wheels are published for macOS (Intel + Apple Silicon), Linux (x86-64 + arm64, glibc +
-musl), and Windows x86-64. Every one is installed and executed on the platform it targets
-before it is published; see the smoke jobs in
+musl), and Windows (x86-64 + arm64). Every one is installed and executed on the platform it
+targets before it is published; see the smoke jobs in
 [`release-pypi.yml`](../../.github/workflows/release-pypi.yml).
 
 Anywhere else, pip falls back to the **sdist**, which ships the Python library and no


### PR DESCRIPTION
## Why

goreleaser has shipped a `windows/arm64` standalone binary for a while, but there was no wheel for it. `pip install airom` on a Windows on Arm machine fell through to the sdist. Since #11 that fails honestly rather than installing a library with no scanner, but a wheel is the actual fix.

The binary is CGO-free and cross-compiled like every other target, so this is a matrix entry, not new build machinery.

## The change

| | |
|---|---|
| `wheels` | `+ { id: windows-arm64, goos: windows, goarch: arm64, tag: py3-none-win_arm64 }` |
| `smoke` | `+ { id: windows-arm64, runs-on: windows-11-arm }` |
| `sdk/python/README.md` | platform list now says Windows (x86-64 + arm64) |

8 wheels, 8 smoke tests, so the coverage check added in #11 stays satisfied. That check is also what would have caught this PR if I had added the wheel and forgotten the test.

## Both labels verified, not assumed

This is the lesson from the `macos-13` entry in #11, where a retired label queued for 38 minutes instead of failing fast:

- **`windows-11-arm`** appears in `actions/runner-images` as *Windows 11 Arm64*, current and not deprecated.
- **`setup-python` 3.12 on arm64 Windows** exists: `actions/python-versions` ships `win32`/`arm64` CPython for 3.11 through 3.15, newest 3.12.x being 3.12.10.

Neither was taken on faith, but neither is proof the job runs. That is what the smoke test on this PR is for — it installs the wheel on a real Windows on Arm runner and executes the binary.

## What to watch

The `Smoke windows-arm64` job is the whole point. If `windows-11-arm` has thin capacity the way `macos-13` did, it shows up here rather than as a broken release. Check `runner_name` before assuming contention if it sits in `queued`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
